### PR TITLE
升级baidu.browser的浏览器判断方式为特征判断

### DIFF
--- a/src/baidu/browser.js
+++ b/src/baidu/browser.js
@@ -53,7 +53,7 @@ baidu.browser = baidu.browser || function(){
 	} else if ( win.opera && opera.version ) {
 		//老版本Opera(<=12)，>=15以后采用Chrome内核
 		result.opera = opera.version();
-	} else if ( win.netscape && nav.product == "Gecko" ) {
+	} else if ( win.netscape ) {
 		result.isGecko = true;
 		result.gecko = getver("rv", ":");
 		result.firefox = getver("Firefox");

--- a/src/baidu/browser.js
+++ b/src/baidu/browser.js
@@ -3,8 +3,8 @@
 /*
  * @fileoverview
  * @name baidu.browser
- * @author meizz
- * @create 2012-06-29
+ * @author gucong
+ * @create 2013-09-17
  * @modify
  */
 
@@ -20,54 +20,86 @@
  * @grammar baidu.browser.isGecko
  * @grammar baidu.browser.isStrict
  * @grammar baidu.browser.isWebkit
+ * @grammar baidu.browser.gecko
+ * @grammar baidu.browser.webkit
+ * @grammar baidu.browser.sogou
+ * @grammar baidu.browser.liebao
+ * @grammar baidu.browser.maxthon
+ * @grammar baidu.browser.theworld
+ * @grammar baidu.browser.taoBrowser
+ * @grammar baidu.browser.coolnovo
  */
+
 baidu.browser = baidu.browser || function(){
-    var ua = navigator.userAgent;
-    
-    var result = {
-        isStrict : document.compatMode == "CSS1Compat"
-        ,isGecko : /gecko/i.test(ua) && !/like gecko/i.test(ua)
-        ,isWebkit: /webkit/i.test(ua)
-    };
+	var win = window,
+		ext = win.external || {},
+ 		doc = win.document,
+		ie = doc.documentMode,
+		strict = doc.compatMode,
+		nav = win.navigator,
+		ua = nav.userAgent,
+		result = {
+			isStrict : (strict && strict !== "BackCompat")
+			,isWebkit: false
+			,isGecko: false
+	};
 
-    try{/(\d+\.\d+)/.test(external.max_version) && (result.maxthon = + RegExp['\x241'])} catch (e){};
+	function getver(name, split) {
+		return new RegExp("\\b" + name + (split || "/") + "([\\w.]+)\\b").test(ua) ? RegExp['\x241'] : true;
+	}
 
-    // 蛋疼 你懂的
-    switch (true) {
-        case /msie (\d+\.\d+)/i.test(ua) :
-            result.ie = document.documentMode || + RegExp['\x241'];
-            break;
-        case /chrome\/(\d+\.\d+)/i.test(ua) :
-            result.chrome = + RegExp['\x241'];
-            break;
-        case /(\d+\.\d)?(?:\.\d)?\s+safari\/?(\d+\.\d+)?/i.test(ua) && !/chrome/i.test(ua) :
-            result.safari = + (RegExp['\x241'] || RegExp['\x242']);
-            break;
-        case /firefox\/(\d+\.\d+)/i.test(ua) : 
-            result.firefox = + RegExp['\x241'];
-            break;
-        
-        case /opera(?:\/| )(\d+(?:\.\d+)?)(.+?(version\/(\d+(?:\.\d+)?)))?/i.test(ua) :
-            result.opera = + ( RegExp["\x244"] || RegExp["\x241"] );
-            break;
-    }
-           
-    baidu.extend(baidu, result);
+	if( ie || !doc.querySelector ){
+		result.ie = ie || (result.isStrict ? "XMLHttpRequest" in win ? 7 : 6 : 5);
+	} else if ( win.opera && opera.version ) {
+		//老版本Opera(<=12)，>=15以后采用Chrome内核
+		result.opera = opera.version();
+	} else if ( win.netscape && nav.product == "Gecko" ) {
+		result.isGecko = true;
+		result.gecko = getver("rv", ":");
+		result.firefox = getver("Firefox");
+	} else {
+		ua = nav.appVersion;
 
-    return result;
+		result.webkit = getver("\\w*WebKit");
+		result.isWebkit = true;
+
+		if( win.chrome ){
+			//判定为Chrome
+			result.chrome = getver("Chrome");
+		} else if ( /^Apple/.test(nav.vendor) ){
+			//判定为Safari
+			result.safari = getver("Version");
+		}
+
+		function setver(name, split){
+			var ver = getver(name, split);
+			if(ver !== true){
+				return result[name.toLowerCase()] = ver;
+			}
+		}
+
+		//搜狗浏览器
+		(ext.SEVersion && (result.sogou = ext.SEVersion() || true)) ||
+
+		//猎豹
+		(ext.LiebaoGetVersion && (result.liebao = ext.LiebaoGetVersion() || true)) ||
+		
+		//傲游
+		( "max_version" in ext && setver("Maxthon") ) ||
+		
+		//TheWorld
+		setver("TheWorld", "\\s") ||
+
+		//淘宝浏览器
+		setver("TaoBrowser") ||
+
+		//枫树浏览器
+		( "coolnovo" in ext && setver("CoolNovo") );
+		
+		//QQ浏览器,360急速,360安全3款浏览器无探测方法
+	}
+
+	baidu.extend(baidu, result);
+
+	return result;
 }();
-/*
-baidu.browser.chrome = /chrome\/(\d+\.\d+)/i.test(navigator.userAgent) ? + RegExp['\x241'] : undefined;
-baidu.browser.firefox = /firefox\/(\d+\.\d+)/i.test(navigator.userAgent) ? + RegExp['\x241'] : undefined;
-baidu.browser.ie = baidu.ie = /msie (\d+\.\d+)/i.test(navigator.userAgent) ? (document.documentMode || + RegExp['\x241']) : undefined;
-baidu.browser.isGecko = /gecko/i.test(navigator.userAgent) && !/like gecko/i.test(navigator.userAgent);
-baidu.browser.isStrict = document.compatMode == "CSS1Compat";
-baidu.browser.isWebkit = /webkit/i.test(navigator.userAgent);
-baidu.browser.opera = /opera(\/| )(\d+(\.\d+)?)(.+?(version\/(\d+(\.\d+)?)))?/i.test(navigator.userAgent) ?  + ( RegExp["\x246"] || RegExp["\x242"] ) : undefined;
-baidu.browser.safari = /(\d+\.\d)?(?:\.\d)?\s+safari\/?(\d+\.\d+)?/i.test(ua) && !/chrome/i.test(ua) ? + (RegExp['\x241'] || RegExp['\x242']) : undefined;
-try {
-    if (/(\d+\.\d+)/.test(external.max_version)) {
-        baidu.browser.maxthon = + RegExp['\x241'];
-    }
-} catch (e) {}
-//*/

--- a/src/baidu/browser.js
+++ b/src/baidu/browser.js
@@ -31,75 +31,75 @@
  */
 
 baidu.browser = baidu.browser || function(){
-	var win = window,
-		ext = win.external || {},
- 		doc = win.document,
-		ie = doc.documentMode,
-		strict = doc.compatMode,
-		nav = win.navigator,
-		ua = nav.userAgent,
-		result = {
-			isStrict : (strict && strict !== "BackCompat")
-			,isWebkit: false
-			,isGecko: false
-	};
+    var win = window,
+        ext = win.external || {},
+        doc = win.document,
+        ie = doc.documentMode,
+        strict = doc.compatMode,
+        nav = win.navigator,
+        ua = nav.userAgent,
+        result = {
+            isStrict : (strict && strict !== "BackCompat")
+            ,isWebkit: false
+            ,isGecko: false
+    };
 
-	function getver(name, split) {
-		return new RegExp("\\b" + name + (split || "/") + "([\\w.]+)\\b").test(ua) ? RegExp['\x241'] : true;
-	}
+    function getver(name, split) {
+        return new RegExp("\\b" + name + (split || "/") + "([\\w.]+)\\b").test(ua) ? RegExp['\x241'] : true;
+    }
 
-	if( ie || !doc.querySelector ){
-		result.ie = ie || (result.isStrict ? "XMLHttpRequest" in win ? 7 : 6 : 5);
-	} else if ( win.opera && opera.version ) {
-		//老版本Opera(<=12)，>=15以后采用Chrome内核
-		result.opera = opera.version();
-	} else if ( win.netscape ) {
-		result.isGecko = true;
-		result.gecko = getver("rv", ":");
-		result.firefox = getver("Firefox");
-	} else {
-		ua = nav.appVersion;
+    if( ie || !doc.querySelector ){
+        result.ie = ie || (result.isStrict ? "XMLHttpRequest" in win ? 7 : 6 : 5);
+    } else if ( win.opera && opera.version ) {
+        //老版本Opera(<=12)，>=15以后采用Chrome内核
+        result.opera = opera.version();
+    } else if ( win.netscape ) {
+        result.isGecko = true;
+        result.gecko = getver("rv", ":");
+        result.firefox = getver("Firefox");
+    } else {
+        ua = nav.appVersion;
 
-		result.webkit = getver("\\w*WebKit");
-		result.isWebkit = true;
+        result.webkit = getver("\\w*WebKit");
+        result.isWebkit = true;
 
-		if( win.chrome ){
-			//判定为Chrome
-			result.chrome = getver("Chrome");
-		} else if ( /^Apple/.test(nav.vendor) ){
-			//判定为Safari
-			result.safari = getver("Version");
-		}
+        if( win.chrome ){
+            //判定为Chrome
+            result.chrome = getver("Chrome");
+        } else if ( /^Apple/.test(nav.vendor) ){
+            //判定为Safari
+            result.safari = getver("Version");
+        }
 
-		function setver(name, split){
-			var ver = getver(name, split);
-			if(ver !== true){
-				return result[name.toLowerCase()] = ver;
-			}
-		}
+        function setver(name, split){
+            var ver = getver(name, split);
+            if(ver !== true){
+                return result[name.toLowerCase()] = ver;
+            }
+        }
 
-		//搜狗浏览器
-		(ext.SEVersion && (result.sogou = ext.SEVersion() || true)) ||
+        //搜狗浏览器
+        (ext.SEVersion && (result.sogou = ext.SEVersion() || true)) ||
 
-		//猎豹
-		(ext.LiebaoGetVersion && (result.liebao = ext.LiebaoGetVersion() || true)) ||
-		
-		//傲游
-		( "max_version" in ext && setver("Maxthon") ) ||
-		
-		//TheWorld
-		setver("TheWorld", "\\s") ||
+        //猎豹
+        (ext.LiebaoGetVersion && (result.liebao = ext.LiebaoGetVersion() || true)) ||
+        
+        //傲游
+        ( "max_version" in ext && setver("Maxthon") ) ||
+        
+        //TheWorld
+        setver("TheWorld", "\\s") ||
 
-		//淘宝浏览器
-		setver("TaoBrowser") ||
+        //淘宝浏览器
+        setver("TaoBrowser") ||
 
-		//枫树浏览器
-		( "coolnovo" in ext && setver("CoolNovo") );
-		
-		//QQ浏览器,360急速,360安全3款浏览器无探测方法
-	}
+        //枫树浏览器
+        ( "coolnovo" in ext && setver("CoolNovo") );
+        
+        //QQ浏览器,360急速,360安全3款浏览器无探测方法
+    }
 
-	baidu.extend(baidu, result);
+    baidu.extend(baidu, result);
 
-	return result;
+    return result;
 }();


### PR DESCRIPTION
大幅降低对userAgent的依赖，转而依赖特征检测

IE高版使用document.documentMode判断
IE低版本使用DOM特征判断
兼容IE11
Opera使用opera.version()获取版号
火狐依赖window.netscape判断，但是版本号依然需要从userAgent中获取
增加gecko和webkit的内核版本号获取
webkit内核浏览器改为从navigator.appVersion获取版本号
增加国内5种浏览器的识别：搜狗浏览器、猎豹浏览器、傲游浏览器、世界之窗浏览器、淘宝浏览器、枫树浏览器
